### PR TITLE
Set DB pool defaults and logging via env-configurable values

### DIFF
--- a/sdk/models/config.go
+++ b/sdk/models/config.go
@@ -20,6 +20,9 @@ type Config struct {
 	DbUserTech        string `envconfig:"DB_USER_TECH"`
 	DbPasswordTech    string `envconfig:"DB_PASSWORD_TECH"`
 	DbNameTech        string `envconfig:"DB_NAME_TECH"`
+	DbMaxOpenConns    string `envconfig:"DB_MAX_OPEN_CONNS"`
+	DbMaxIdleConns    string `envconfig:"DB_MAX_IDLE_CONNS"`
+	DbConnMaxLifetime string `envconfig:"DB_CONN_MAX_LIFETIME_MINUTES"`
 
 	// Aws Queue Details
 	QueueConnectionString string `envconfig:"AZURE_SERVICEBUS_CONNECTION_STRING"`

--- a/sdk/services/sdkService.go
+++ b/sdk/services/sdkService.go
@@ -146,10 +146,6 @@ func ProcessCommApiData(data *sdkModels.CommApiRequestBody, snsClient *sns.SNS, 
 		return sdkModels.CommApiResponseBody{Success: false}, fmt.Errorf("error inserting data into input table %s for mobile %s and channel %s: %v", data.InputTableName, data.Mobile, data.Channel, err)
 	}
 
-	if err := database.InsertData(data.InputTableName, data.DbClient, dbMappedData); err != nil {
-		utils.Error(fmt.Errorf("error inserting data into input table %s for mobile %s and channel %s: %v", data.InputTableName, data.Mobile, data.Channel, err))
-		return sdkModels.CommApiResponseBody{Success: false}, fmt.Errorf("error inserting data into input table %s for mobile %s and channel %s: %v", data.InputTableName, data.Mobile, data.Channel, err)
-	}
 	// Send the map to AWS Queue
 	err = queue.SendMessageToAwsQueue(snsClient, dataMap, topicArn, subject)
 	if err != nil {


### PR DESCRIPTION
## **User description**
https://wecredit.atlassian.net/browse/CE-16


___

## **CodeAnt-AI Description**
Configure DB pools from environment and stop duplicate input inserts

### What Changed
- Database connections for Tech and Analytics now apply pool limits (max open, max idle, connection lifetime) from environment variables; sensible defaults are used when variables are missing or invalid
- Pool configuration logs which defaults are used and prints a summary of applied pool settings for each database
- Removed a duplicated insert that could cause the same input row to be written twice before queuing

### Impact
`✅ Lower DB connection exhaustion`
`✅ Fewer duplicate inserts`
`✅ Clearer DB pool configuration logs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
